### PR TITLE
fix: streaming session responsiveness (46s -> <1s session start)

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -173,37 +173,36 @@ class PersonaPlexStreamingSession:
         self._is_ready = False
 
     def start(self):
-        """Initialize the session by resetting the manager's warm lm_gen state.
-        
-        Creating a new LMGen that wraps the already-streaming manager.lm breaks
-        step_system_prompts (depformer.is_streaming assertion). Instead, reuse
-        manager.lm_gen directly — reset_streaming + step_system_prompts works
-        on it, as proven by load() pre-warm and infer_stream().
+        """Initialize the session by restoring the pre-warmed lm_gen state.
+
+        Uses _restore_primed_state() instead of re-running step_system_prompts
+        (~46s) so session starts are instant after load() warmup.
         """
-        from moshi.offline import wrap_with_system_tags
-        
         self.manager._apply_optimizations()
         self.manager.load()
-        
-        final_voice_prompt = _ensure_voice_prompt_exists(self.voice_prompt_path)
 
         with self.manager._lock:
-            # Reuse the manager's warm lm_gen rather than creating a new one.
             self.lm_gen = self.manager.lm_gen
             self.frame_size = int(self.manager.mimi.sample_rate / self.manager.mimi.frame_rate)
 
-            # Load voice/text prompts and reset streaming state (same path as infer_stream).
-            if final_voice_prompt.endswith('.pt'):
-                self.lm_gen.load_voice_prompt_embeddings(final_voice_prompt)
-            else:
-                self.lm_gen.load_voice_prompt(final_voice_prompt)
-            self.lm_gen.text_prompt_tokens = self.manager.text_tokenizer.encode(
-                wrap_with_system_tags(self.text_prompt)
-            )
-            self.manager.mimi.reset_streaming()
-            self.manager.other_mimi.reset_streaming()
-            self.lm_gen.reset_streaming()
-            self.lm_gen.step_system_prompts(self.manager.mimi)
+            if not self.manager._restore_primed_state():
+                # _lm_primed_state not available yet — fall back to full setup
+                from moshi.offline import wrap_with_system_tags
+                final_voice_prompt = _ensure_voice_prompt_exists(self.voice_prompt_path)
+                if final_voice_prompt.endswith('.pt'):
+                    self.lm_gen.load_voice_prompt_embeddings(final_voice_prompt)
+                else:
+                    self.lm_gen.load_voice_prompt(final_voice_prompt)
+                self.lm_gen.text_prompt_tokens = self.manager.text_tokenizer.encode(
+                    wrap_with_system_tags(self.text_prompt)
+                )
+                self.manager.mimi.reset_streaming()
+                self.manager.other_mimi.reset_streaming()
+                self.lm_gen.reset_streaming()
+                self.lm_gen.step_system_prompts(self.manager.mimi)
+                self.manager.mimi.reset_streaming()
+                self.manager._save_primed_state()
+
             self._is_ready = True
 
     def step(self, audio_chunk: np.ndarray) -> Tuple[Optional[np.ndarray], Optional[str]]:

--- a/voice_loop.py
+++ b/voice_loop.py
@@ -173,9 +173,25 @@ class VoiceLoop:
                 utils.play_wav_file_interruptible, tmp, self._playback_interrupt
             )
             self._speaking = False
+            # Invalidate the streaming session — tts_stream modified lm_gen state,
+            # so the next session must start fresh with _restore_primed_state().
+            self._streaming_session = None
+            # Drain stale audio that accumulated while the GPU was busy with TTS
+            # so the model won't respond to audio that's already minutes old.
+            drained = 0
+            if self._audio_queue is not None:
+                while not self._audio_queue.empty():
+                    try:
+                        self._audio_queue.get_nowait()
+                        drained += 1
+                    except Exception:
+                        break
+            if drained:
+                logger.debug("say_audio: drained %d stale audio chunks after TTS playback", drained)
             await self._set_activity("listening", "playback complete")
         except Exception as e:
             self._speaking = False
+            self._streaming_session = None
             logger.error("say_audio error: %s", e)
         finally:
             if os.path.exists(tmp):


### PR DESCRIPTION
PersonaPlexStreamingSession.start() previously called step_system_prompts from scratch every time (~46s), even though load() already pre-warmed the lm_gen state. This caused 46s gaps after every TTS utterance when the streaming session was re-initialized.

Changes to utils.py:
- PersonaPlexStreamingSession.start(): replace full step_system_prompts setup with manager._restore_primed_state() — session start is now <1s instead of ~46s. Falls back to full setup if primed state is not yet available (e.g. if called before load() warmup completes).

Changes to voice_loop.py:
- say_audio(): after TTS playback completes, reset _streaming_session = None so the next session picks up a clean lm_gen state via _restore_primed_state. tts_stream() modifies lm_gen state, so the old session would be on a corrupted state if not reset.
- say_audio(): drain stale audio chunks from _audio_queue after TTS playback so the model doesn't respond to audio that accumulated minutes ago while the GPU was locked by token generation.
- say_audio() exception path: also reset _streaming_session = None to ensure clean state even on error.

Result:
- /voice-hear response latency: 46-88s -> ~16s
- Streaming session start: 46s -> <1s
- Startup greeting plays immediately after warmup
- No more stale audio responses from minutes-old microphone input