### PR TITLE
Stabilize voice duplex startup and improve 4bit checkpoint handling

### DIFF
--- a/quantize.py
+++ b/quantize.py
@@ -98,14 +98,25 @@ class _BNBLinear4bit(nn.Module):
         self.out_features = linear.out_features
 
         # We initialize the bnb layer
-        self.bnb_layer = bnb.nn.Linear4bit(
-            self.in_features,
-            self.out_features,
-            bias=linear.bias is not None,
-            compute_dtype=torch.bfloat16,
-            quant_type="nf4",
-            double_quant=True,
-        )
+        try:
+            # Older/newer bitsandbytes builds use different kwarg names.
+            self.bnb_layer = bnb.nn.Linear4bit(
+                self.in_features,
+                self.out_features,
+                bias=linear.bias is not None,
+                compute_dtype=torch.bfloat16,
+                quant_type="nf4",
+                compress_statistics=True,
+            )
+        except TypeError:
+            self.bnb_layer = bnb.nn.Linear4bit(
+                self.in_features,
+                self.out_features,
+                bias=linear.bias is not None,
+                compute_dtype=torch.bfloat16,
+                quant_type="nf4",
+                double_quant=True,
+            )
         # Load weights into the bnb layer
         self.bnb_layer.weight.data.copy_(linear.weight.data)
         if linear.bias is not None:

--- a/simple_renderer.py
+++ b/simple_renderer.py
@@ -5,7 +5,11 @@ import subprocess
 import textwrap
 from datetime import datetime
 
-from config import VOICE_AUTO_START_ON_LAUNCH, VOICE_CAPTURE_KEY_LABEL
+from config import (
+    PERSONAPLEX_VOICE_PROMPT,
+    VOICE_AUTO_START_ON_LAUNCH,
+    VOICE_CAPTURE_KEY_LABEL,
+)
 from config import LLM_DIAG_TIMEOUT_SECONDS
 from process_utils import force_exit_now
 from smoke_test_runner import (
@@ -356,7 +360,7 @@ class SimpleRenderer:
             if pm and vl:
 
                 async def _do_hear():
-                    stream = pm.hear_stream(text, pm._primed_for or "")
+                    stream = pm.hear_stream(text, PERSONAPLEX_VOICE_PROMPT)
                     await vl.say_stream(stream)
 
                 asyncio.create_task(_do_hear())
@@ -377,7 +381,7 @@ class SimpleRenderer:
 
                 async def _do_hear_file():
                     stream = pm.hear_stream(
-                        "", pm._primed_for or "", user_wav_path=path
+                        "", PERSONAPLEX_VOICE_PROMPT, user_wav_path=path
                     )
                     await vl.say_stream(stream)
 

--- a/tui_renderer.py
+++ b/tui_renderer.py
@@ -11,6 +11,7 @@ import time
 from datetime import datetime
 
 from config import (
+    PERSONAPLEX_VOICE_PROMPT,
     LLM_DIAG_TIMEOUT_SECONDS,
     VOICE_AUTO_START_ON_LAUNCH,
     VOICE_CAPTURE_KEY_CODE,
@@ -740,7 +741,7 @@ class TUIRenderer:
             if pm and vl:
 
                 async def _do_hear():
-                    stream = pm.hear_stream(text, pm._primed_for or "")
+                    stream = pm.hear_stream(text, PERSONAPLEX_VOICE_PROMPT)
                     await vl.say_stream(stream)
 
                 asyncio.create_task(_do_hear())
@@ -763,7 +764,7 @@ class TUIRenderer:
 
                 async def _do_hear_file():
                     stream = pm.hear_stream(
-                        "", pm._primed_for or "", user_wav_path=path
+                        "", PERSONAPLEX_VOICE_PROMPT, user_wav_path=path
                     )
                     await vl.say_stream(stream)
 

--- a/utils.py
+++ b/utils.py
@@ -331,6 +331,7 @@ class PersonaPlexManager:
         # each call can restore it in milliseconds instead of re-running setup.
         self._lm_primed_state = None
         self._optimizations_applied = False
+        self._loaded = False
         # Dedicated executor for sequential, low-jitter inference
         from concurrent.futures import ThreadPoolExecutor
 
@@ -537,7 +538,7 @@ class PersonaPlexManager:
         global MimiModel, LMGen, loaders, sentencepiece, moshi_run_inference
         import torch
 
-        if self.mimi is not None:
+        if self._loaded:
             return
 
         # Apply optimizations BEFORE importing anything from moshi
@@ -566,13 +567,16 @@ class PersonaPlexManager:
                 return torch.cuda.memory_allocated() / (1024**3)
             return 0.0
 
-        vram_before = get_vram()
-        self._status("PersonaPlexManager: starting in-process model load...")
-
         quantize_type = getattr(_config, "PERSONAPLEX_QUANTIZE", "")
         is_quantizing = quantize_type and quantize_type not in ("none", "None")
 
         with self._lock:
+            if self._loaded:
+                return
+
+            vram_before = get_vram()
+            self._status("PersonaPlexManager: starting in-process model load...")
+
             from huggingface_hub import hf_hub_download
 
             # If quantizing, isolate GPU completely during the heavy weight load
@@ -619,10 +623,8 @@ class PersonaPlexManager:
                 target_repo = self.repo
                 target_filename = loaders.MOSHI_NAME
                 if quantize_type == "4bit":
-                    target_repo = "brianmatzelle/personaplex-7b-v1-bnb-4bit"
-                    target_filename = "model_bnb_4bit.pt"
                     self._status(
-                        f"PersonaPlexManager: using pre-quantized model from {target_repo}"
+                        "PersonaPlexManager: using base safetensors + post-load 4bit quantization."
                     )
 
                 moshi_weight = hf_hub_download(target_repo, target_filename)
@@ -640,19 +642,31 @@ class PersonaPlexManager:
 
                     # Convert to safetensors if it's a .pt file, then load to CPU
                     if not moshi_weight.endswith(".safetensors"):
-                        self._status(
-                            "PersonaPlexManager: converting .pt to .safetensors for CPU load..."
-                        )
-                        temp_sd = torch.load(moshi_weight, map_location="cpu")
-                        if "model" in temp_sd:
-                            temp_sd = temp_sd["model"]
-                        from safetensors.torch import save_file
-
                         st_path = moshi_weight + ".safetensors"
-                        save_file(temp_sd, st_path)
-                        moshi_weight = st_path
-                        del temp_sd
-                        gc.collect()
+                        if os.path.exists(st_path):
+                            self._status(
+                                "PersonaPlexManager: using cached .safetensors conversion."
+                            )
+                            moshi_weight = st_path
+                        else:
+                            self._status(
+                                "PersonaPlexManager: converting .pt to .safetensors for CPU load..."
+                            )
+                            temp_sd = torch.load(moshi_weight, map_location="cpu")
+                            if "model" in temp_sd:
+                                temp_sd = temp_sd["model"]
+                            from safetensors.torch import save_file
+
+                            # Use a process-unique path to avoid Windows file-mapping
+                            # collisions when multiple app instances are active.
+                            unique_st_path = os.path.join(
+                                tempfile.gettempdir(),
+                                f"{Path(moshi_weight).stem}-{os.getpid()}-{int(time.time() * 1000)}.safetensors",
+                            )
+                            save_file(temp_sd, unique_st_path)
+                            moshi_weight = unique_st_path
+                            del temp_sd
+                            gc.collect()
 
                     state_dict = st_load_file(moshi_weight, device="cpu")
 
@@ -759,9 +773,8 @@ class PersonaPlexManager:
                     warm_err,
                 )
                 self._primed = False
-            except Exception as e:
-                logger.exception("PersonaPlexManager: failed to load models: %s", e)
-                raise
+
+            self._loaded = True
 
     def create_session(
         self, text_prompt: str, voice_prompt_path: str
@@ -773,7 +786,7 @@ class PersonaPlexManager:
         """Return detailed status of the manager and models."""
         with self._lock:
             return {
-                "loaded": self.mimi is not None,
+                "loaded": self._loaded,
                 "device": self.device,
                 "cpu_offload": self.cpu_offload,
                 "optimize_strategy": PERSONAPLEX_OPTIMIZE,
@@ -1079,6 +1092,10 @@ class PersonaPlexManager:
             4.0  # seconds of silence after speech — gives model time to respond
         )
         _LEADING_SILENCE_AMP = 0.02  # skip leading output frames that are nearly silent
+
+        self._apply_optimizations()
+        self.load()
+
         _sample_rate = int(self.mimi.sample_rate)
 
         with _tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as _f:
@@ -1100,9 +1117,6 @@ class PersonaPlexManager:
             )
             full_input = np.concatenate([input_data, trailing])
             user_speech_samples = len(input_data)
-
-            self._apply_optimizations()
-            self.load()
 
             final_voice_prompt = _ensure_voice_prompt_exists(voice_prompt_path)
 
@@ -1361,9 +1375,18 @@ class DebugServer:
         self._server = None
 
     async def start(self):
-        self._server = await asyncio.start_server(
-            self._handle_client, self.host, self.port
-        )
+        try:
+            self._server = await asyncio.start_server(
+                self._handle_client, self.host, self.port
+            )
+        except OSError as e:
+            if getattr(e, "winerror", None) == 10048 or getattr(e, "errno", None) == 10048:
+                logger.warning(
+                    "DebugServer: port %s already in use; skipping socket server startup.",
+                    self.port,
+                )
+                return
+            raise
         logger.info(f"DebugServer: listening on {self.host}:{self.port}")
         async with self._server:
             await self._server.serve_forever()


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across model quantization, voice prompt handling, model loading, and debugging utilities. The most notable changes include more robust handling of model quantization, consistent use of a configurable voice prompt, improved model loading logic to prevent redundant loads and handle file conversions more safely, and enhanced error handling for the debug server.

**Model loading and quantization improvements:**
- Added a `_loaded` flag to the `PersonaPlexManager` class in `utils.py` to prevent redundant model loads and updated all relevant logic to check this flag instead of relying on `self.mimi` alone. The status output now accurately reflects the loaded state (`utils.py`). [[1]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeR334) [[2]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL540-R541) [[3]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL569-R579) [[4]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL776-R789)
- Improved quantized model loading by always using base safetensors with post-load 4bit quantization, and added logic to reuse existing `.safetensors` conversions or create unique temporary paths to avoid file-mapping collisions, especially on Windows (`utils.py`). [[1]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL622-R627) [[2]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeR645-R651) [[3]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL651-R667)
- Updated the initialization of `bnb.nn.Linear4bit` in `quantize.py` to handle different bitsandbytes versions by trying alternative keyword argument names.

**Voice prompt handling:**
- Standardized the use of the `PERSONAPLEX_VOICE_PROMPT` configuration variable in both `simple_renderer.py` and `tui_renderer.py`, replacing the previous usage of `pm._primed_for or ""` for all relevant calls to `pm.hear_stream`. [[1]](diffhunk://#diff-747421809d11ac9be7f8a2671cf2856b415e2c5c70c4bdc36f5511123dae990fL8-R12) [[2]](diffhunk://#diff-747421809d11ac9be7f8a2671cf2856b415e2c5c70c4bdc36f5511123dae990fL359-R363) [[3]](diffhunk://#diff-747421809d11ac9be7f8a2671cf2856b415e2c5c70c4bdc36f5511123dae990fL380-R384) [[4]](diffhunk://#diff-b4586e85f11ac68aebc39faa1c7cb1cfed95b98c0905c2dc690b113de9dac3a6R14) [[5]](diffhunk://#diff-b4586e85f11ac68aebc39faa1c7cb1cfed95b98c0905c2dc690b113de9dac3a6L743-R744) [[6]](diffhunk://#diff-b4586e85f11ac68aebc39faa1c7cb1cfed95b98c0905c2dc690b113de9dac3a6L766-R767)

**Model inference and optimizations:**
- Ensured that model optimizations and loading are always applied before running inference in `hear_stream`, preventing potential errors from uninitialized models. [[1]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeR1095-R1098) [[2]](diffhunk://#diff-09d0cbaf891d623ac245ccf84485a687b554217349ca55557c60b33234b969aeL1104-L1106)

**Debug server robustness:**
- Improved the debug server in `utils.py` to gracefully handle the case where the desired port is already in use, logging a warning and skipping startup instead of crashing.